### PR TITLE
Better highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## Unreleased
+### Added
+- Support for .ipkg and .lidr syntax highlighting
+
+### Changed
+- Improved the regex syntax highlighting
+
+### Fixed

--- a/README.md
+++ b/README.md
@@ -158,12 +158,13 @@ Under active development. Should be mostly working, but there are still features
 If you run into any problems, please raise an issue, or raise a PR if you want to.
 
 ## To Do
-- test on Windows & OSX
-- better syntax highlighting
 - implement Show References
-- literate programming support
-- ipkg support
 - there is more information to add to the metavariables command output
+- semantic highlighting for source code
+- more ipkg integration
+
+## Acknowledgments
+The syntax files are taken from [vscode-idris’s](https://github.com/zjhmale/vscode-idris) port of the [Atom plugin’s](https://github.com/idris-hackers/atom-language-idris) grammars.
 
 ## License
 [MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -121,6 +121,17 @@
         "extensions": [
           ".ipkg"
         ]
+      },
+      {
+        "id": "lidr",
+        "aliases": [
+          "lidr",
+          "Literate Idris",
+          "literate idris"
+        ],
+        "extensions": [
+          ".lidr"
+        ]
       }
     ],
     "grammars": [
@@ -133,6 +144,11 @@
         "language": "ipkg",
         "scopeName": "source.ipkg",
         "path": "./syntaxes/ipkg.tmLanguage.json"
+      },
+      {
+        "language": "lidr",
+        "scopeName": "source.idris.literate",
+        "path": "./syntaxes/lidr.tmLanguage.json"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -111,6 +111,16 @@
         "extensions": [
           ".idr"
         ]
+      },
+      {
+        "id": "ipkg",
+        "aliases": [
+          "iPKG",
+          "ipkg"
+        ],
+        "extensions": [
+          ".ipkg"
+        ]
       }
     ],
     "grammars": [
@@ -118,6 +128,11 @@
         "language": "idris",
         "scopeName": "source.idris",
         "path": "./syntaxes/idris.tmLanguage.json"
+      },
+      {
+        "language": "ipkg",
+        "scopeName": "source.ipkg",
+        "path": "./syntaxes/ipkg.tmLanguage.json"
       }
     ]
   },

--- a/syntaxes/idris.tmLanguage.json
+++ b/syntaxes/idris.tmLanguage.json
@@ -1,66 +1,357 @@
 {
-  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Idris",
+  "scopeName": "source.idris",
+  "fileTypes": ["idr"],
   "patterns": [
     {
-      "include": "#comments"
+      "name": "keyword.control.idris",
+      "match": "\\b(if|then|else|do|let|in|dsl)\\b"
     },
     {
-      "include": "#keywords"
+      "name": "storage.declaration.idris",
+      "match": "\\b(impossible|case|of|total|partial|mutual|infix|infixl|infixr|constructor)\\b"
     },
     {
-      "include": "#strings"
-    }
+      "name": "keyword.control.idris",
+      "match": "\\b(where|with|syntax|proof|postulate|using|namespace|rewrite)\\b"
+    },
+    {
+      "name": "storage.visibility.idris",
+      "match": "\\b(public|private|export|implicit)\\b"
+    },
+    {
+      "name": "comment.line.idris",
+      "match": "(--).*$\n?",
+      "comment": "Line comment"
+    },
+    {
+      "name": "comment.documentation.line.idris",
+      "match": "(\\|\\|\\|).*$\n?",
+      "comment": "Line comment"
+    },
+    {
+      "name": "comment.block.idris",
+      "begin": "\\{-",
+      "end": "-\\}",
+      "comment": "Block comment"
+    },
+    {
+      "begin": "\\b(module)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.idris"
+        }
+      },
+      "end": "($|;|(?=--))",
+      "name": "meta.module.idris",
+      "patterns": [
+        {
+          "match": "([a-zA-Z0-9._']+)",
+          "name": "meta.declaration.module.idris"
+        }
+      ]
+    },
+    {
+      "begin": "\\b(import\\s+public|import)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.idris"
+        }
+      },
+      "end": "($|;|(?=--))",
+      "name": "meta.import.idris",
+      "patterns": [
+        {
+          "match": "([a-zA-Z0-9._']+)",
+          "name": "support.other.module.idris"
+        }
+      ]
+    },
+    { "include": "#param_decl" },
+    { "include": "#data_decl" },
+    { "include": "#function_signature" },
+    { "include": "#ty_expression" }
   ],
   "repository": {
-    "comments": {
+    "param_decl": {
+      "name": "meta.declaration.data.idris",
+      "begin": "\\b(parameters)\\s+(\\()",
+      "end": "(\\))$",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.idris" },
+        "2": { "name": "punctuation.context.begin.idris" }
+      },
+      "endCaptures": { "1": { "name": "punctuation.context.end.idris" } },
+      "patterns": [{ "include": "#ty_expression" }]
+    },
+    "context_signature": {
       "patterns": [
         {
-          "name": "comment.line.double-dash.idris",
-          "match": "--.*$"
-        },
-        {
-          "name": "comment.block.idris",
-          "begin": "{-",
-          "end": "-}"
-        },
-        {
-          "name": "comment.block.documentation",
-          "match": "\\|\\|\\|.*$"
+          "name": "meta.context-signature.idris",
+          "comment": "For things like '(Eq a, Show b) =>'\nIt begins with '(' either followed by ') =>' on the same line,\nor anything but ')' until the end of line.",
+          "begin": "(\\()((?=.*\\)\\s*=>)|(?=[^)]*$))",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.context.begin.idris"
+            }
+          },
+          "end": "(\\))\\s*(=>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.context.end.idris"
+            },
+            "2": {
+              "name": "keyword.operator.double-arrow.idris"
+            }
+          },
+          "patterns": [{ "include": "#ty_expression" }]
         }
       ]
     },
-    "keywords": {
+    "parameter_type": {
+      "comment": "Parameter types in a type signature",
       "patterns": [
         {
-          "name": "keyword.idris",
-          "match": "\\b(as|case|codata|data|of|import|module|record|where)\\b"
+          "name": "meta.parameter.named.idris",
+          "comment": "(x : Nat)",
+          "begin": "(\\()([\\w']+)\\s*(:)(?!:)",
+          "beginCaptures": {
+            "1": { "name": "punctuation.delimiter.idris" },
+            "2": { "name": "variable.parameter.idris" },
+            "3": { "name": "keyword.operator.annot.idris" }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": { "name": "punctuation.delimiter.idris" }
+          },
+          "patterns": [{ "include": "#ty_expression" }]
         },
         {
-          "name": "keyword.control",
-          "match": "\\b(if|then|else)\\b"
-        },
-        {
-          "name": "keyword.operator",
-          "match": "(:|->|=>|=|\\|)"
-        },
-        {
-          "name": "keyword.operator.new",
-          "match": "\\b(Refl|Nil)\\b"
+          "name": "meta.parameter.implicit.idris",
+          "comment": "{auto p : a = b}",
+          "begin": "(\\{)((auto|default .+)\\s+)?([\\w']+)\\s*(:)(?!:)",
+          "beginCaptures": {
+            "1": { "name": "punctuation.delimiter.idris" },
+            "2": { "name": "storage.modifier.idris" },
+            "4": { "name": "variable.parameter.idris" },
+            "5": { "name": "keyword.operator.annot.idris" }
+          },
+          "end": "\\}",
+          "endCaptures": {
+            "0": { "name": "punctuation.delimiter.idris" }
+          },
+          "patterns": [{ "include": "#ty_expression" }]
         }
       ]
     },
-    "strings": {
+    "ty_expression": {
+      "patterns": [
+        { "name": "keyword.operator.arrow.idris", "match": "->" },
+        { "include": "#parameter_type" },
+        { "include": "#language_const" },
+        { "include": "#operator" },
+        { "include": "#quasiquote" },
+        { "include": "#infix_function" },
+        { "include": "#prelude_type" },
+        { "include": "#delimiter" },
+        { "include": "#number_nat" },
+        { "include": "#number_integer" },
+        { "include": "#number_float" },
+        { "include": "#unit" },
+        { "include": "#string_double" },
+        { "include": "#string_single" },
+        { "include": "#data_ctor" }
+      ]
+    },
+    "function_signature": {
+      "name": "meta.function.type-signature.idris",
+      "begin": "(([\\w']+)|\\(([|!%$+\\-.,=</>:]+)\\))\\s*(:)(?!:)",
+      "beginCaptures": {
+        "2": {
+          "name": "entity.name.function.idris"
+        },
+        "3": {
+          "name": "entity.name.function.idris"
+        },
+        "4": {
+          "name": "keyword.operator.colon.idris"
+        }
+      },
+      "end": "(;|(?=--)|(?<=[^\\s>])\\s*(?!->)\\s*$)",
+      "patterns": [
+        { "include": "#context_signature" },
+        { "include": "#ty_expression" }
+      ],
+      "comment": "The end patterm is a bit tricky. It's either ';' or something, at the end of the line,\nbut not '->', because a type signature can be multiline. Though, it doesn't help, if you\nbreak the signature before arrows."
+    },
+    "language_const": {
+      "patterns": [
+        {
+          "name": "constant.language.unit.idris",
+          "match": "\\(\\)"
+        },
+        {
+          "name": "constant.language.bottom.idris",
+          "match": "_\\|_"
+        },
+        {
+          "name": "constant.language.underscore.idris",
+          "match": "\\b_\\b"
+        }
+      ]
+    },
+    "escape_characters": {
+      "patterns": [
+        {
+          "name": "constant.character.escape.ascii.idris",
+          "match": "\\\\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\\"'\\&])"
+        },
+        {
+          "name": "constant.character.escape.octal.idris",
+          "match": "\\\\o[0-7]+|\\\\x[0-9A-Fa-f]+|\\\\[0-9]+"
+        },
+        {
+          "name": "constant.character.escape.control.idris",
+          "match": "\\^[A-Z@\\[\\]\\\\\\^_]"
+        }
+      ]
+    },
+    "data_decl": {
+      "name": "meta.declaration.data.idris",
+      "begin": "\\b(data|codata|class|instance|interface|implementation|record)\\s",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.idris" }
+      },
+      "end": "\\b(where)\\b|(=)|$",
+      "endCaptures": {
+        "1": { "name": "keyword.other.idris" },
+        "2": { "name": "keyword.operator.idris" }
+      },
+      "patterns": [{ "include": "#ty_expression" }]
+    },
+    "data_ctor": {
+      "patterns": [
+        {
+          "name": "entity.name.function.ctor.idris",
+          "match": "\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)*\\b"
+        }
+      ]
+    },
+    "prelude_type": {
+      "name": "support.type.builtin.idris",
+      "match": "\\b(Type|Int|Nat|Integer|Float|Char|String|Ptr|Bits8|Bits16|Bits32|Bits64|Bool)\\b"
+    },
+    "operator": {
+      "name": "keyword.operator.idris",
+      "match": "\\?[-!#\\$%&\\*\\+\\.\\/<=>@\\\\^|~:]+|[-!#\\$%&\\*\\+\\.\\/<=>@\\\\^|~:\\?][-!#\\$%&\\*\\+\\.\\/<=>@\\\\^|~:]*"
+    },
+    "quasiquote": {
+      "name": "meta.quasiquote.idris",
+      "begin": "`{",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.quasiquote.idris"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "keyword.operator.quasiquote.idris"
+        }
+      },
+      "patterns": [
+        {
+          "name": "keyword.operator.arrow.idris",
+          "match": "->"
+        },
+        { "include": "#parameter_type" },
+        { "include": "#ty_expression" }
+      ]
+    },
+    "infix_function": {
+      "name": "keyword.operator.function.infix.idris",
+      "begin": "`",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.entity.idris"
+        }
+      },
+      "end": "`",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.entity.idris"
+        }
+      }
+    },
+    "delimiter": {
+      "name": "punctuation.delimiter.idris",
+      "match": "[\\(\\)\\[\\]{},;]"
+    },
+    "unit": {
+      "match": "\\(\\)",
+      "name": "constant.unit.idris"
+    },
+    "number_nat": {
+      "name": "constant.numeric.idris",
+      "match": "\\b(S|Z)\\b"
+    },
+    "number_integer": {
+      "match": "\\b([0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\\b",
+      "name": "constant.numeric.idris",
+      "comment": "integer literal"
+    },
+    "number_float": {
+      "match": "\\b([0-9]+\\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\\b",
+      "name": "constant.numeric.float.idris",
+      "comment": "float literal"
+    },
+    "string_double": {
       "name": "string.quoted.double.idris",
       "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.idris"
+        }
+      },
       "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.idris"
+        }
+      },
       "patterns": [
         {
-          "name": "constant.character.escape.idris",
-          "match": "\\\\."
+          "include": "#escape_characters"
+        }
+      ]
+    },
+    "string_single": {
+      "name": "string.quoted.single.idris",
+      "match": "(')(?:(?:\\\\\")|(?:\\\\[0-9]+)|(\\\\o[0-7]+)|(\\\\x[0-9a-fA-F]+)|(?:[^'])|(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL))(')",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.string.begin.idris"
+        },
+        "2": {
+          "name": "constant.character.escape.octal.idris"
+        },
+        "3": {
+          "name": "constant.character.escape.hexadecimal.idris"
+        },
+        "4": {
+          "name": "constant.character.escape.control.idris"
+        },
+        "5": {
+          "name": "punctuation.definition.string.end.idris"
+        }
+      },
+      "patterns": [
+        {
+          "name": "invalid.illegal.idris",
+          "match": "\\\\n"
         }
       ]
     }
   },
-  "scopeName": "source.idris"
+  "uuid": "4dd16092-ffa5-4ba4-8075-e5da9f368a72"
 }

--- a/syntaxes/ipkg.tmLanguage.json
+++ b/syntaxes/ipkg.tmLanguage.json
@@ -1,0 +1,31 @@
+{
+  "name": "Idris Ipkg",
+  "scopeName": "source.ipkg",
+  "fileTypes": ["ipkg"],
+  "patterns": [
+    {
+      "name": "comment.line.ipkg",
+      "match": "(--).*$\n?",
+      "comment": "Line comment"
+    },
+    {
+      "name": "comment.block.ipkg",
+      "begin": "\\{-",
+      "end": "-\\}",
+      "comment": "Block comment"
+    },
+    {
+      "name": "keyword.control.ipkg",
+      "match": "\\b(package|opts|modules|sourcedir|makefile|objs|executable|main|libs|pkgs|tests)\\b"
+    },
+    {
+      "name": "constant.language.ipkg",
+      "match": "\\b(brief|version|readme|license|author|maintainer|homepage|sourceloc|bugtracker)\\b"
+    },
+    {
+      "name": "string.quoted.double.ipkg",
+      "begin": "\"",
+      "end": "\""
+    }
+  ]
+}

--- a/syntaxes/lidr.tmLanguage.json
+++ b/syntaxes/lidr.tmLanguage.json
@@ -1,0 +1,14 @@
+{
+  "name": "Idris (Literate)",
+  "scopeName": "source.idris.literate",
+  "fileTypes": ["lidr"],
+  "patterns": [
+    {
+      "match": "^(?!>)(.*)(?=\n)",
+      "name": "comment.line.documentation.idris.literate"
+    },
+    {
+      "include": "source.idris"
+    }
+  ]
+}


### PR DESCRIPTION
## Context
While I would like to get semantic highlighting working properly for source code, the bulk of the highlighting is always going to come from the Textmate grammar. Semantic highlighting is great for vars, types and functions, but it doesn't cover most of the keywords and operators. Also, many VS themes don't support it yet.

See also https://github.com/meraymond2/idris-vscode/issues/5.

## Changes
The existing grammar only covers a fraction of Idris' syntax. Rather than spend ages replicating other plugins' highlighting, I'll just borrow them, with appropriate attribution. The grammars are nice and self-contained, so it doesn't really impinge on any other aspect of the plugin.