### PR TITLE
Dont send type query unless identifier under cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Improved the regex syntax highlighting
 
 ### Fixed
+- Fixed an invisible bug where it would try to get the type of the whole document when hovering over a space

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -16,6 +16,7 @@ export class Provider implements vscode.HoverProvider {
   ): vscode.ProviderResult<vscode.Hover> {
     return new Promise(async (res) => {
       const range = document.getWordRangeAtPosition(position)
+      if (!range) res(null)
       const name = document.getText(range)
       const reply = await this.client.typeOf(name)
       if (reply.ok) {


### PR DESCRIPTION
This isn't going to fix [this issue](https://github.com/meraymond2/idris-vscode/issues/1), but it will stop sending extra pointless requests to the IDE process. 

If you call `document.getWordRangeAtPosition(position)` when the position is a space between words, it returns null. And if you call `document.getText(null)`, you get the whole document. If you send the whole document to Idris, it doesn't return a type, but it's quite heavy for a meaningless action.