### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 ### Added
+### Changed
+### Fixed
+
+# 0.0.4
+### Added
 - Support for .ipkg and .lidr syntax highlighting
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "meraymond",
   "displayName": "Idris Language",
   "description": "Idris language support.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# 0.0.4
### Added
- Support for .ipkg and .lidr syntax highlighting

### Changed
- Improved the regex syntax highlighting
- Updated dev dependencies for security

### Fixed
- Fixed an invisible bug where it would try to get the type of the whole document when hovering over a space
