### PR TITLE
V0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 ## Unreleased
 ### Added
 ### Changed
-- Bump dev dependencies to appease our dependabot overlords
+### Fixed
+
+# 0.0.5
+### Added
 - Added a config flag to enable Idris 2 mode.
 - Added a config option to turn off the hover behaviour.
 - Added a warning for trying to call Version from Idris 2.
+
+### Changed
+- Bump dev dependencies to appease our dependabot overlords
 
 ### Fixed
 - Fix hover text in inappropriate contexts (https://github.com/meraymond2/idris-vscode/issues/1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "idris-vscode",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "meraymond",
   "displayName": "Idris Language",
   "description": "Idris language support.",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/meraymond2/idris-vscode"
   },
   "engines": {
-    "vscode": "^1.49.0"
+    "vscode": "^1.44.0"
   },
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
# 0.0.5
### Added
- Added a config flag to enable Idris 2 mode.
- Added a config option to turn off the hover behaviour.
- Added a warning for trying to call Version from Idris 2.

### Changed
- Bump dev dependencies to appease our dependabot overlords

### Fixed
- Fix hover text in inappropriate contexts (https://github.com/meraymond2/idris-vscode/issues/1)
- Fixed a bug in the text-mate highlighting where it didn’t handle all of the possible bracket types after backticks.
- Fixed a bug where the diagnostics didn't work with Idris 2.
- Fixed a bug where Idris 2 wouldn't find the ipkg file, and complain about module names (https://github.com/meraymond2/idris-vscode/issues/12).