### PR TITLE
Load warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 ### Added
 ### Changed
+- Added a warning when load file fails in Idris2 because of errors.
+
 ### Fixed
 
 # 0.0.5

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -253,16 +253,18 @@ export const printDefinitionSelection = (client: IdrisClient) => async () => {
 export const loadFile = async (
   client: IdrisClient,
   document: vscode.TextDocument
-): Promise<void> =>
-  new Promise((res) => {
-    if (document.languageId === "idris") {
-      res(
-        client.loadFile(document.fileName).then(() => {
-          state.currentFile = document.fileName
-        })
-      )
-    } else res()
-  })
+): Promise<void> => {
+  if (document.languageId === "idris") {
+    const reply = await client.loadFile(document.fileName)
+    if (reply.ok) {
+      state.currentFile = document.fileName
+    } else if (state.idris2Mode) {
+      status("File failed to typecheck — commands will not work until it does.")
+    } else {
+      status("Failed to load file.")
+    }
+  }
+}
 
 export const makeCase = (client: IdrisClient) => async () => {
   const selection = currentWord()

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -254,12 +254,16 @@ export const loadFile = async (
   client: IdrisClient,
   document: vscode.TextDocument
 ): Promise<void> => {
+  if (state.statusMessage) state.statusMessage.dispose()
+
   if (document.languageId === "idris") {
     const reply = await client.loadFile(document.fileName)
     if (reply.ok) {
       state.currentFile = document.fileName
     } else if (state.idris2Mode) {
-      status("File failed to typecheck — commands will not work until it does.")
+      state.statusMessage = vscode.window.setStatusBarMessage(
+        "File failed to typecheck — commands will work incorrectly until it does."
+      )
     } else {
       status("Failed to load file.")
     }

--- a/src/state.ts
+++ b/src/state.ts
@@ -16,6 +16,7 @@ export interface State {
   idrisProc: ChildProcess | null
   idrisProcDir: string | null
   idris2Mode: boolean
+  statusMessage: vscode.Disposable | null
   virtualDocState: Record<string, VirtualDocInfo>
 }
 
@@ -27,6 +28,7 @@ export const state: State = {
   idrisProc: null,
   idrisProcDir: null,
   idris2Mode: false,
+  statusMessage: null,
   virtualDocState: {},
 }
 


### PR DESCRIPTION
Addresses https://github.com/meraymond2/idris-vscode/issues/18.

I quickly double checked the behaviour, and the commands _do_ run, but with the wrong result. You'll get back blank answers, or messages about variables not existing. 

Long term, this should get fixed in Idris2, but for now I at least wanted the warning. Status bar warnings are a bit subtle, but having a pop up would get really annoying after the first time.

