### PR TITLE
Diagnostic refix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added a warning when load file fails in Idris2 because of errors.
 
 ### Fixed
+- Fixed a bug that could lead to incorrect paths in the diagnostic URIs.
 
 # 0.0.5
 ### Added


### PR DESCRIPTION
It sounds like there is an issue where I was adding the workspace path to an already absolute path. It's possible that idris 2 isn't consistent about when it returns an absolute or a relative path, so it's easier just to detect it.