### PR TITLE
Bump versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Unreleased
 ### Added
 ### Changed
+### Fixed
+
+## 0.0.6
+### Added
+### Changed
 - Added a warning when load file fails in Idris2 because of errors.
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "meraymond",
   "displayName": "Idris Language",
   "description": "Idris language support.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 0.0.6
### Added
### Changed
- Added a warning when load file fails in Idris2 because of errors.

### Fixed
- Fixed a bug that could lead to incorrect paths in the diagnostic URIs.
