### PR TITLE
Show types of metavariables on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Added
 ### Changed
+- Trim leading `?` so hover can show types of metavariables.
 ### Fixed
 
 ## 0.0.6

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -257,7 +257,8 @@ export class Provider implements vscode.HoverProvider {
           if (docStateAtPos !== "code") res(null)
 
           const name = document.getText(range)
-          const reply = await this.client.typeOf(name)
+          const trimmed = name.startsWith("?") ? name.slice(1, name.length) : name
+          const reply = await this.client.typeOf(trimmed)
           if (reply.ok) {
             res({ contents: [{ value: reply.typeOf, language: "idris" }] })
           } else {


### PR DESCRIPTION
Completes https://github.com/meraymond2/idris-vscode/issues/22.

A quick note, in Idris 1 if there are multiple meta-variables with the same name, it will always show the type of the first one (that also applies to regular values, the type-of command is global, and not context aware). Idris 2 doesn't have this problem, by not allowing duplicate meta-variable names.