### PR TITLE
Only prompt reload on relevant config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 - Trim leading `?` so hover can show types of metavariables.
 ### Fixed
+- Fix a bug where extension would prompt for reload on _any_ config change.
 
 ## 0.0.6
 ### Added

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -13,7 +13,7 @@ const warningToDiagnostic = (reply: InfoReply.Warning): vscode.Diagnostic => {
 }
 
 export const handleWarning = (reply: InfoReply.Warning): void => {
-  const { diagnostics, idrisProcDir, idris2Mode } = state
+  const { diagnostics, idrisProcDir } = state
   const filename = reply.err.filename
 
   // Idris2 sometimes uses relative file paths, which aren’t parsed into file URIs correctly on their own.

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -257,7 +257,9 @@ export class Provider implements vscode.HoverProvider {
           if (docStateAtPos !== "code") res(null)
 
           const name = document.getText(range)
-          const trimmed = name.startsWith("?") ? name.slice(1, name.length) : name
+          const trimmed = name.startsWith("?")
+            ? name.slice(1, name.length)
+            : name
           const reply = await this.client.typeOf(trimmed)
           if (reply.ok) {
             res({ contents: [{ value: reply.typeOf, language: "idris" }] })

--- a/src/state.ts
+++ b/src/state.ts
@@ -6,7 +6,7 @@ import { VirtualDocInfo } from "./providers/virtual-docs"
 
 // I’m not using the Memento API because I don’t want persistence across sessions, and I do want type-safety.
 
-type HoverBehaviour = "Type Of" | "Nothing"
+export type HoverBehaviour = "Type Of" | "Nothing"
 
 export interface State {
   client: IdrisClient | null


### PR DESCRIPTION
I had naïvely assumed that the `onDidChangeConfiguration` listener would only listen to events to this extensions config, but I noticed when testing that it fires for everything, so it would ask to reload the editor if I change the colour theme.

Since I'm now responding to changes to specific config values, it only asks to restart if it has to, i.e. if it needs to restart the Idris process.