### PR TITLE
Save before cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,15 @@
           "default": false,
           "description": "Configure the extension to work with Idris2. Targets the latest release, currently 0.2.1. Note that not all commands are implemented yet."
         },
+        "idris.autosave": {
+          "type": "string",
+          "enum": [
+            "always",
+            "prompt",
+            "never"
+          ],
+          "description": "Whether to save the current file before executing a command. Commands that read files operate on the state of that file on disk, so if it is not saved, the command might produce inaccurate output."
+        },
         "idris.hoverAction": {
           "type": "string",
           "enum": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,12 @@ import * as completions from "./providers/completions"
 import * as hover from "./providers/hover"
 import * as messageHighlighting from "./providers/message-highlighting"
 import * as virtualDocs from "./providers/virtual-docs"
-import { HoverBehaviour, initialiseState, state } from "./state"
+import {
+  AutoSaveBehaviour,
+  HoverBehaviour,
+  initialiseState,
+  state,
+} from "./state"
 
 const promptReload = () => {
   const action = "Reload Now"
@@ -51,6 +56,14 @@ export const activate = (context: vscode.ExtensionContext) => {
 
   vscode.workspace.onDidChangeConfiguration(
     (changeEvent: vscode.ConfigurationChangeEvent) => {
+      if (changeEvent.affectsConfiguration("idris.autosave")) {
+        const autosave:
+          | AutoSaveBehaviour
+          | undefined = vscode.workspace
+          .getConfiguration("idris")
+          .get("autosave")
+        if (autosave) state.autosave = autosave
+      }
       if (changeEvent.affectsConfiguration("idris.hoverAction")) {
         const hoverAction:
           | HoverBehaviour

--- a/src/state.ts
+++ b/src/state.ts
@@ -6,9 +6,11 @@ import { VirtualDocInfo } from "./providers/virtual-docs"
 
 // I’m not using the Memento API because I don’t want persistence across sessions, and I do want type-safety.
 
+export type AutoSaveBehaviour = "always" | "prompt" | "never"
 export type HoverBehaviour = "Type Of" | "Nothing"
 
 export interface State {
+  autosave: AutoSaveBehaviour
   client: IdrisClient | null
   currentFile: string
   diagnostics: vscode.DiagnosticCollection
@@ -21,6 +23,7 @@ export interface State {
 }
 
 export const state: State = {
+  autosave: "always",
   client: null,
   currentFile: "",
   diagnostics: vscode.languages.createDiagnosticCollection("Idris Errors"),
@@ -44,6 +47,9 @@ export const initialiseState = () => {
   const extensionConfig = vscode.workspace.getConfiguration("idris")
   const idrisPath: string = extensionConfig.get("idrisPath") || ""
   const idris2Mode: boolean = extensionConfig.get("idris2Mode") || false
+  const autosave: AutoSaveBehaviour | undefined = extensionConfig.get(
+    "autosave"
+  )
   const hoverAction: HoverBehaviour | undefined = extensionConfig.get(
     "hoverAction"
   )
@@ -83,5 +89,6 @@ export const initialiseState = () => {
   state.idrisProc = idrisProc
   state.idrisProcDir = idrisProcDir
   state.idris2Mode = idris2Mode
+  if (autosave) state.autosave = autosave
   if (hoverAction) state.hoverAction = hoverAction
 }


### PR DESCRIPTION
A workaround for https://github.com/meraymond2/idris-vscode/issues/24. It's not possible for now to run commands on unsaved files, but I've added an option to autosave files before running those commands. 

I'm not really happy with the way that the `prompt` option is implemented. The QuickPick isn't the correct UI element here, but as far as I can tell, vscode doesn't expose a real save confirmation prompt to extensions. It's possible it's buried somewhere where I can't find it though. 