### PR TITLE
Bump to 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 ### Changed
 - Trim leading `?` so hover can show types of metavariables.
+- Bump client version to 0.1.4, which has better Idris 2 support.
 ### Fixed
 - Fix a bug where extension would prompt for reload on _any_ config change.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "idris-vscode",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -49,15 +49,15 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.21",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.21.tgz",
-			"integrity": "sha512-tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ==",
+			"version": "13.13.36",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.36.tgz",
+			"integrity": "sha512-ctzZJ+XsmHQwe3xp07gFUq4JxBaRSYzKHPgblR76//UanGST7vfFNF0+ty5eEbgTqsENopzoDK090xlha9dccQ==",
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.49.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
-			"integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
+			"integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
@@ -720,9 +720,9 @@
 			}
 		},
 		"idris-ide-client": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/idris-ide-client/-/idris-ide-client-0.1.3.tgz",
-			"integrity": "sha512-eJyL7l7r7LJwYY4HqC38XPi0/zZPeHdXDkPqBQLubESFlcXxZMTklzO54H39HemOMnQe5Ir8dYmSMjcjxYXfEg=="
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/idris-ide-client/-/idris-ide-client-0.1.4.tgz",
+			"integrity": "sha512-S/EAt0ZaofpqfNuxVK2f9JOpe/YaI371/eaiFhzZR29yF0almaUmQar3xC5fYLKntrbaZMop46g0hvcPfW1J8g=="
 		},
 		"ignore": {
 			"version": "4.0.6",
@@ -1152,9 +1152,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
-			"integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
 			"dev": true
 		},
 		"progress": {

--- a/package.json
+++ b/package.json
@@ -186,15 +186,15 @@
     "lint": "tsc --noEmit && prettier --check --write 'src/**/*.ts' && eslint src --ext .ts --fix"
   },
   "dependencies": {
-    "idris-ide-client": "0.1.3"
+    "idris-ide-client": "0.1.4"
   },
   "devDependencies": {
-    "@types/node": "^13.13.20",
-    "@types/vscode": "^1.44.0",
+    "@types/node": "^13.13.36",
+    "@types/vscode": "^1.52.0",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "eslint": "^6.8.0",
-    "prettier": "^2.1.2",
+    "prettier": "^2.2.1",
     "typescript": "^3.9.7",
     "vsce": "1.76.0"
   }


### PR DESCRIPTION
The latest version of the client has a couple of workarounds to support some more commands in Idris 2, and has the fix for a failed add-clause reply. That will fix one of the issues in this issue https://github.com/meraymond2/idris-vscode/issues/24.