### PR TITLE
Pass 0 console width explicitly to idris proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bump client version to 0.1.4, which has better Idris 2 support.
 ### Fixed
 - Fix a bug where extension would prompt for reload on _any_ config change.
+- Workaround a bug in Idris 2 where it would mangle messages based on a mis-inferred terminal width.
 
 ## 0.0.6
 ### Added

--- a/src/state.ts
+++ b/src/state.ts
@@ -66,7 +66,9 @@ export const initialiseState = () => {
   directory, so it’s necessary to pass the --find-ipkg flag. It looks for the ipkg
   in parent directories of the process, so it’s also necessary to start the Idris
   process in the workspace directory.*/
-  const procArgs = idris2Mode ? ["--ide-mode", "--find-ipkg"] : ["--ide-mode"]
+  const procArgs = idris2Mode
+    ? ["--ide-mode", "--find-ipkg", "--console-width", "0"]
+    : ["--ide-mode"]
   const procOpts = idrisProcDir ? { cwd: idrisProcDir } : {}
   const idrisProc = spawn(idrisPath, procArgs, procOpts)
 


### PR DESCRIPTION
Workaround to solve one of the issues described here: https://github.com/meraymond2/idris-vscode/issues/23.

The Idris IDE process inserts new lines into replies based on the width of the terminal, presumably because it's using the same code as the Idris REPL. When it's not running inside a terminal, it should infer the width as 0, and not do any wrapping. On some systems, it seems like it's inferring this incorrectly, and it tries to wrap after every word.

Passing the console width in explicitly fixes this for now, until the [fix](https://github.com/idris-lang/Idris2/pull/870) is merged and released.