### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## Unreleased
 ### Added
 ### Changed
+### Fixed
+
+## 0.0.7
+### Added
+### Changed
 - Trim leading `?` so hover can show types of metavariables.
-- Bump client version to 0.1.4, which has better Idris 2 support.
+- Bump idris-ide-client version to 0.1.4, which has better Idris 2 support.
 ### Fixed
 - Fix a bug where extension would prompt for reload on _any_ config change.
 - Workaround a bug in Idris 2 where it would mangle messages based on a mis-inferred terminal width.

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "idris-vscode",
   "publisher": "meraymond",
   "displayName": "Idris Language",
-  "description": "Idris language support.",
-  "version": "0.0.6",
+  "description": "Language support for Idris and Idris 2.",
+  "version": "0.0.7",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 0.0.7
### Added
### Changed
- Trim leading `?` so hover can show types of metavariables.
- Bump idris-ide-client version to 0.1.4, which has better Idris 2 support.
### Fixed
- Fix a bug where extension would prompt for reload on _any_ config change.
- Workaround a bug in Idris 2 where it would mangle messages based on a mis-inferred terminal width.