### PR TITLE
Handle nested block comments

### DIFF
--- a/syntaxes/idris.tmLanguage.json
+++ b/syntaxes/idris.tmLanguage.json
@@ -29,12 +29,7 @@
       "match": "(\\|\\|\\|).*$\n?",
       "comment": "Line comment"
     },
-    {
-      "name": "comment.block.idris",
-      "begin": "\\{-",
-      "end": "-\\}",
-      "comment": "Block comment"
-    },
+    { "include": "#multiline_comment" },
     {
       "begin": "\\b(module)\\b",
       "beginCaptures": {
@@ -73,6 +68,18 @@
     { "include": "#ty_expression" }
   ],
   "repository": {
+    "multiline_comment": {
+      "name": "comment.block.idris",
+      "begin": "\\{-",
+      "end": "-\\}",
+      "comment": "Block comment",
+      "patterns": [
+        {
+          "include": "#multiline_comment",
+          "name": "comment.block.idris"
+        }
+      ]
+    },
     "param_decl": {
       "name": "meta.declaration.data.idris",
       "begin": "\\b(parameters)\\s+(\\()",


### PR DESCRIPTION
Correctly handle nested block comments, which are valid Idris grammar as long as they're balanced. Currently these are highlighted incorrectly, see https://github.com/meraymond2/idris-vscode/issues/36.

![image](https://user-images.githubusercontent.com/13559686/107126340-32709c00-68a7-11eb-9cc7-cc370aa02f58.png)

This fix was quite painless because I found https://github.com/soegaard/racket-highlight-for-github, where they solved this exact problem. So thank you @soegaard!