### PR TITLE
Implement v2 warnings for new cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Added
 ### Changed
+- Don't try to execute v2 commands if not in v2 mode, show warning instead.
 ### Fixed
 
 ## 0.0.8

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -22,9 +22,9 @@ const trimMeta = (name: string) =>
 
 const status = (msg: string) => vscode.window.setStatusBarMessage(msg, 2000)
 
-const unimplementedV2 = (actionName: string): void => {
+export const v2Only = (actionName: string): void => {
   vscode.window.showWarningMessage(
-    actionName + " is not yet implemented for Idris 2."
+    actionName + " is only available in Idris 2."
   )
   return
 }
@@ -208,6 +208,8 @@ export const docsForSelection = (client: IdrisClient) => async () => {
 }
 
 export const generateDef = (client: IdrisClient) => async () => {
+  if (!state.idris2Mode) return v2Only("Generate Definition")
+
   const selection = currentWord()
   if (selection) {
     const { name, line } = selection
@@ -373,9 +375,8 @@ export const proofSearch = (client: IdrisClient) => async () => {
 }
 
 export const version = (client: IdrisClient) => async () => {
-  if (state.idris2Mode) return unimplementedV2("Version")
-
   const { major, minor, patch, tags } = await client.version()
+  const nonEmptyTags = tags.filter(Boolean)
   const msg =
     "Idris version is " +
     major +
@@ -383,6 +384,6 @@ export const version = (client: IdrisClient) => async () => {
     minor +
     "." +
     patch +
-    (tags.length ? "-" + tags.join("-") : "")
+    (nonEmptyTags.length ? "-" + nonEmptyTags.join("-") : "")
   vscode.window.showInformationMessage(msg)
 }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import { IdrisClient } from "idris-ide-client"
 import { state } from "../state"
+import { v2Only } from "../commands"
 export const selector = { language: "idris" }
 
 type DocState =
@@ -300,6 +301,10 @@ export class Provider implements vscode.HoverProvider {
           type ? { contents: [{ value: type, language: "idris" }] } : null
         )
       case "Type At":
+        if (!state.idris2Mode) {
+          v2Only("Type At")
+          return null
+        }
         return this.typeAt(document, position).then((type) =>
           type ? { contents: [{ value: type, language: "idris" }] } : null
         )


### PR DESCRIPTION
It occurred to me that I forgot to unblock the :version command, which now works in V2 (mostly, as long as you've loaded a file already), and that I need to instead block the new V2 only commands if it's not in v2 mode.