### PR TITLE
Handle insert past doc end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 - Don't try to execute v2 commands if not in v2 mode, show warning instead.
 ### Fixed
+- Fix bug where VS couldn't insert past end of document.
 
 ## 0.0.8
 ### Added

--- a/src/editing.ts
+++ b/src/editing.ts
@@ -51,6 +51,10 @@ export const lineAfterDecl = (declLine: number): number => {
     nextLineNumber < document.lineCount + 1;
     nextLineNumber++
   ) {
+    if (nextLineNumber === document.lineCount) {
+      insertAtLine = nextLineNumber
+      break
+    }
     const nextLine = document.lineAt(nextLineNumber)
     const hasIndentedText = /^\s+\S+/.test(nextLine.text)
     if (!hasIndentedText) {
@@ -104,7 +108,11 @@ export const insertLine = (
   const editor = vscode.window.activeTextEditor
   editor?.edit((eb) => {
     const pos = new vscode.Position(line, column)
-    eb.insert(pos, text + "\n")
+    // If you try to insert past the end of the file, it will simply append it
+    // to the final line, so in that case start with a newline.
+    const prefix = line === editor.document.lineCount ? "\n" : ""
+    const suffix = "\n"
+    eb.insert(pos, prefix + text + suffix)
   })
 }
 


### PR DESCRIPTION
If you are on the final line of the document and attempt to execute a command that inserts a new line VS would throw an error. It's trying to check whether the next line is indented and fails because that line doesn't exist. To fix that, I'm checking first whether it's the final line.

VS will not error if you try to insert past the end of the document, but it will just append it to the final position, so it will end up on the same line. To get around this, I conditionally start the new content with a newline, again just by checking if it's the final line.

This issue only arises if VS isn't set to insert a final newline on save, otherwise it would save before the command, insert a newline, and then insert there.

Should fix the second half of https://github.com/meraymond2/idris-vscode/issues/45
