### PR TITLE
Stop matching sooner in function signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Don't try to execute v2 commands if not in v2 mode, show warning instead.
 ### Fixed
 - Fix bug where VS couldn't insert past end of document.
+- Change the function_signature highlighting rule to add fewer scopes, fixing the highlighting of case statements within the signature.
 
 ## 0.0.8
 ### Added

--- a/syntaxes/idris.tmLanguage.json
+++ b/syntaxes/idris.tmLanguage.json
@@ -187,7 +187,7 @@
           "name": "keyword.operator.colon.idris"
         }
       },
-      "end": "(;|(?=--)|(?<=[^\\s>])\\s*(?!->)\\s*$)",
+      "end": "(?!->)",
       "patterns": [
         { "include": "#context_signature" },
         { "include": "#ty_expression" }


### PR DESCRIPTION
The function_signature regex captures too much, resulting in keywords being incorrectly scoped within a signature. I've simplified the end statement, so that this rule only affects the function name, which is I think the only necessary part of the rule.

See https://github.com/meraymond2/idris-vscode/issues/46 for screenshots. You can see that removing the scope `"meta.function.type-signature.idris"` from most of the elements on that line results in _more_ tokens being highlighted, not fewer.