### PR TITLE
Remove console width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 ### Changed
 - Don't try to execute v2 commands if not in v2 mode, show warning instead.
+- Stop passing console width flag to Idris 2 proc, as no longer needed.
 ### Fixed
 - Fix bug where VS couldn't insert past end of document.
 - Change the function_signature highlighting rule to add fewer scopes, fixing the highlighting of case statements within the signature.

--- a/src/state.ts
+++ b/src/state.ts
@@ -67,7 +67,7 @@ export const initialiseState = () => {
   in parent directories of the process, so it’s also necessary to start the Idris
   process in the workspace directory.*/
   const procArgs = idris2Mode
-    ? ["--ide-mode", "--find-ipkg", "--console-width", "0"]
+    ? ["--ide-mode", "--find-ipkg"]
     : ["--ide-mode"]
   const procOpts = idrisProcDir ? { cwd: idrisProcDir } : {}
   const idrisProc = spawn(idrisPath, procArgs, procOpts)


### PR DESCRIPTION
The bug that made this flag necessary has been fixed in Idris2, so I'm removing it. See https://github.com/meraymond2/idris-vscode/pull/30