### PR TITLE
v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Unreleased
 ### Added
 ### Changed
+### Fixed
+
+## 0.0.9
+### Added
+### Changed
 - Don't try to execute v2 commands if not in v2 mode, show warning instead.
 - Stop passing console width flag to Idris 2 proc, as no longer needed.
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "idris-vscode",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "meraymond",
   "displayName": "Idris Language",
   "description": "Language support for Idris and Idris 2.",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 0.0.9
### Added
### Changed
- Don't try to execute v2 commands if not in v2 mode, show warning instead.
- Stop passing console width flag to Idris 2 proc, as no longer needed.
### Fixed
- Fix bug where VS couldn't insert past end of document.
- Change the function_signature highlighting rule to add fewer scopes, fixing the highlighting of case statements within the signature.