### PR TITLE
Add lidr to hover selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "onLanguage:idris"
+    "onLanguage:idris",
+    "onLanguage:lidr"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -189,7 +190,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "lint": "tsc --noEmit && prettier --fix --write 'src/**/*.ts' && eslint src --ext .ts --fix",
+    "lint": "tsc --noEmit && prettier --write 'src/**/*.ts' && eslint src --ext .ts --fix",
     "test": "NODE_ENV=test npx mocha --recursive --require ts-node/register --extensions ts 'test/**/*.ts'"
   },
   "dependencies": {


### PR DESCRIPTION
Activates the extension for `.lidr` files too, and adds them to the hover selector. 

Since I don't have any semantic information about the doc, I'm currently doing a best-effort guess as to whether the cursor is hovering over the code or a comment or a word inside a string. The IDE process doesn't distinguish. I've added an extra case for lidr files, but I should make it more specific. Ideally I can reuse the code for normal files, just for lines that start with `>`. At the moment it doesn't account for comments/strings. 

The syntax highlighting doesn't account for multi-line block comments within lidr either, but that's a stretch. 

Update: that's all fixed, I can reuse the existing code to walk the file and work out what kind of token we're hovering over, I'm just doing it for the code block rather than the whole file. 