### PR TITLE
Return when resolving futures

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -53,7 +53,7 @@ const ensureLoaded = (client: IdrisClient): Promise<void> =>
     if (doc) {
       await autosave(doc)
       if (doc && doc.fileName !== state.currentFile) {
-        res(loadFile(client, doc))
+        return res(loadFile(client, doc))
       }
     }
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -248,8 +248,8 @@ const typeOf =
   (document: vscode.TextDocument, position: vscode.Position): Promise<string | null> =>
     new Promise(async (res) => {
       const range = document.getWordRangeAtPosition(position)
-      if (!range) res(null)
-      if (!overCode(document, position)) res(null)
+      if (!range) return res(null)
+      if (!overCode(document, position)) return res(null)
 
       const name = document.getText(range)
       const trimmed = name.startsWith("?") ? name.slice(1, name.length) : name
@@ -262,8 +262,8 @@ const typeAt =
   (document: vscode.TextDocument, position: vscode.Position): Promise<string | null> =>
     new Promise(async (res) => {
       const range = document.getWordRangeAtPosition(position)
-      if (!range) res(null)
-      if (!overCode(document, position)) res(null)
+      if (!range) return res(null)
+      if (!overCode(document, position)) return res(null)
 
       const name = document.getText(range)
       const trimmed = name.startsWith("?") ? name.slice(1, name.length) : name


### PR DESCRIPTION
This came up while investigating a — I believe — [unrelated issue](https://github.com/meraymond2/idris-vscode/issues/58) around hovering. I noticed when watching the debug logs for hover that it was being very noisy. This is because when the subject of the hover wasn't valid, I was resolving the Promise early, but not returning early, so it would still make the call to the ide process. I don't believe this was enough to cause serious lag, but it's still undesirable. 