### PR TITLE
More lidr stuff

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,6 @@
   },
   "plugins": ["@typescript-eslint"],
   "rules": {
-    "@typescript-eslint/class-name-casing": "warn",
     "@typescript-eslint/semi": ["error", "never"],
     "@typescript-eslint/no-unused-vars": [
       "warn",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 ### Added
-- Hover support for .lidr files.
+- Adds more ide support for .lidr files, mainly hover and diagnostics, and some commands.
 ### Changed
 ### Fixed
 - Fixed a bug where hover would send erroneous typecheck requests that weren't displayed, but slowed down the process.

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
           "Literate Idris",
           "literate idris"
         ],
+        "configuration": "./language-configuration.json",
         "extensions": [
           ".lidr"
         ]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -283,7 +283,7 @@ export const printDefinitionSelection = (client: IdrisClient) => async () => {
 export const loadFile = async (client: IdrisClient, document: vscode.TextDocument): Promise<void> => {
   if (state.statusMessage) state.statusMessage.dispose()
 
-  if (document.languageId === "idris") {
+  if (document.languageId === "idris" || document.languageId === "lidr") {
     const reply = await client.loadFile(document.fileName)
     if (reply.ok) {
       state.currentFile = document.fileName

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -297,13 +297,22 @@ export const loadFile = async (client: IdrisClient, document: vscode.TextDocumen
   }
 }
 
+// Some lidr replies have duplicated `> `s.
+const fixLidrPrefix = (s: string): string =>
+  s.startsWith("> > ")
+    ? s
+        .split("\n")
+        .map((line) => "> " + line.slice(4, line.length))
+        .join("\n")
+    : s
+
 export const makeCase = (client: IdrisClient) => async () => {
   const selection = currentWord()
   if (selection) {
     const { name, line } = selection
     ensureLoaded(client)
     const reply = await client.makeCase(trimMeta(name), line + 1)
-    const caseStmt = reply.caseClause.trim()
+    const caseStmt = fixLidrPrefix(reply.caseClause.trim())
     if (caseStmt) {
       // The reply doesn’t preserve indentation, so if we’re replacing the whole
       // line, we want to first re-add the original indentation. Adding the

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -336,8 +336,10 @@ export const makeLemma = (client: IdrisClient) => async () => {
       const editor = vscode.window.activeTextEditor
       editor?.edit((eb) => {
         // when making multiple changes, they need to use the same edit-builder
-        const declPos = new vscode.Position(prevEmptyLine(line), 0)
-        eb.insert(declPos, "\n" + reply.declaration + "\n")
+        const docLang = editor.document.languageId
+        const declPos = new vscode.Position(prevEmptyLine(line, docLang), 0)
+        const newline = docLang === "lidr" ? "> \n" : "\n"
+        eb.insert(declPos, newline + reply.declaration + "\n")
         eb.replace(selection.range, reply.metavariable)
       })
     } else {

--- a/src/editing.ts
+++ b/src/editing.ts
@@ -64,7 +64,7 @@ export const lineAfterDecl = (declLine: number): number => {
 /**
  * Get the first empty line above the current line.
  */
-export const prevEmptyLine = (fromLine: number): number => {
+export const prevEmptyLine = (fromLine: number, languageId: string): number => {
   const defaultTo = fromLine - 1
   const editor = vscode.window.activeTextEditor
   const document = editor?.document
@@ -72,7 +72,8 @@ export const prevEmptyLine = (fromLine: number): number => {
   let insertAtLine
   for (let line = fromLine - 1; line > 0; line--) {
     const prevLine = document.lineAt(line)
-    if (prevLine.isEmptyOrWhitespace) {
+    const isEmptyLine = languageId === "lidr" ? /^>\s*$/.test(prevLine.text) : prevLine.isEmptyOrWhitespace
+    if (isEmptyLine) {
       insertAtLine = line
       break
     }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -1,15 +1,23 @@
+import { extname, isAbsolute } from "path"
 import * as vscode from "vscode"
 import { InfoReply } from "idris-ide-client"
 import { state } from "../state"
-import { isAbsolute } from "path"
 import { rmLocDesc } from "./diagnostic-utils"
 
 const warningToDiagnostic = (reply: InfoReply.Warning): vscode.Diagnostic => {
-  const { start, end, warning } = reply.err
-  const range = new vscode.Range(
-    new vscode.Position(start.line - 1, start.column - 1),
-    new vscode.Position(end.line - 1, end.column)
-  )
+  const { start, end, warning, filename } = reply.err
+  const isLidr = extname(filename) === ".lidr"
+  // .lidr positions are returned as if they’re normal Idris files, so they’re
+  // off by two, for the `> ` at the beginning.
+  const range = isLidr
+    ? new vscode.Range(
+        new vscode.Position(start.line - 1, start.column + 1),
+        new vscode.Position(end.line - 1, end.column + 2)
+      )
+    : new vscode.Range(
+        new vscode.Position(start.line - 1, start.column - 1),
+        new vscode.Position(end.line - 1, end.column)
+      )
   const editedWarning = rmLocDesc(warning)
   return new vscode.Diagnostic(range, editedWarning)
 }
@@ -19,13 +27,7 @@ export const handleWarning = (reply: InfoReply.Warning): void => {
   const filename = reply.err.filename
 
   // Idris2 sometimes uses relative file paths, which aren’t parsed into file URIs correctly on their own.
-  if (isAbsolute(filename)) {
-    const uri = vscode.Uri.file(filename)
-    const existing = diagnostics.get(uri) || []
-    diagnostics.set(uri, existing.concat(warningToDiagnostic(reply)))
-  } else if (idrisProcDir) {
-    const uri = vscode.Uri.file(idrisProcDir + "/" + filename)
-    const existing = diagnostics.get(uri) || []
-    diagnostics.set(uri, existing.concat(warningToDiagnostic(reply)))
-  }
+  const uri = isAbsolute(filename) ? vscode.Uri.file(filename) : vscode.Uri.file(idrisProcDir + "/" + filename)
+  const existing = diagnostics.get(uri) || []
+  diagnostics.set(uri, existing.concat(warningToDiagnostic(reply)))
 }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -230,8 +230,8 @@ const overCode = (document: vscode.TextDocument, position: vscode.Position): boo
     // Run the DocStateParser on just the code block that the hover position is within.
     let blockStartLine = position.line
     let blockEndLine = position.line
-    while (lidrLineIsCode(document, blockStartLine)) blockStartLine--
-    while (lidrLineIsCode(document, blockEndLine)) blockEndLine++
+    while (lidrLineIsCode(document, blockStartLine) && blockStartLine > 0) blockStartLine--
+    while (lidrLineIsCode(document, blockEndLine) && blockEndLine <= document.lineCount) blockEndLine++
     const blockStart = new vscode.Position(blockStartLine, 0)
     const blockEnd = new vscode.Position(blockEndLine + 1, 0)
     const block = new vscode.Range(blockStart, blockEnd)


### PR DESCRIPTION
This is most of the commands working. I wasn't loading lidr files correctly before, with that, you can hover over things defined in-file, and we get diagnostics too.

The main issue with lidr files is that the IDE replies are inconsistent. Warning positions are off by 2, the prefix being `> ` (I tried without the whitespace, and it seems to be required, so at least it's consistently 2). Some of the text insertion commands work correctly, some randomly add extra arrows and or whitespace in front of the reply. `:make-with` is the worst, the second line starts with `> >   > `, so there's lots of ugly prefix-fixing code. It's working on my test files, but I'm not confident that it'll work on every input. I might move some of the reply-fixing to the ide-client, where it's easier to test, but this should do for now.