### PR TITLE
Syntax highlighting for idris markdown blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 ### Added
+- Syntax highlighting for idris/idris2 code blocks in markdown files.
 ### Changed
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "idris-vscode",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -166,6 +166,12 @@
         "extensions": [
           ".lidr"
         ]
+      },
+      {
+        "id": "idris-markdown",
+        "aliases": [],
+        "configuration": "./language-configuration.json",
+        "extensions": []
       }
     ],
     "grammars": [
@@ -183,6 +189,17 @@
         "language": "lidr",
         "scopeName": "source.idris.literate",
         "path": "./syntaxes/lidr.tmLanguage.json"
+      },
+      {
+        "language": "idris-markdown",
+        "scopeName": "markdown.idris.codeblock",
+        "path": "./syntaxes/idris-codeblock.tmLanguage.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.idris": "idris"
+        }
       }
     ]
   },

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,5 @@
-{ nixpkgs ? import <nixpkgs> {} }:
+with (import <unstable> {});
 
-with nixpkgs;
 mkShell {
   name = "idris-plugin";
   buildInputs = [

--- a/syntaxes/idris-codeblock.tmLanguage.json
+++ b/syntaxes/idris-codeblock.tmLanguage.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#idris-code-block"
+    }
+  ],
+  "repository": {
+    "idris-code-block": {
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(idris2?)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "4": {
+          "name": "fenced_code.block.language.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language.attributes.markdown"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.idris",
+          "patterns": [
+            {
+              "include": "source.idris"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.idris.codeblock"
+}


### PR DESCRIPTION
Syntax highlighting for idris code blocks inside markdown files. Just follows this [example](https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example).

![image](https://user-images.githubusercontent.com/13559686/130688192-6fcbdfa2-a09b-4ffb-adf4-b74522200bc8.png)
