### PR TITLE
Markdown blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## Unreleased
 ### Added
 - Syntax highlighting for idris/idris2 code blocks in markdown files.
+- `Idris: Activate Extension` command, to manually activate when working with non-idris files.
+- Support for commands in idris2 blocks in markdown files.
 ### Changed
 ### Fixed
+- Support completions for Idris 1 .lidr files.
 
 ## 0.0.10
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you want to test local changes to the extension, build it with `npm install &
 ## Idris 2
 Currently the extension will default to v1. If you want it to use Idris 2, change the path in the configuration to your Idris 2 binary, and tick the `Idris 2 Mode` checkbox.
 
-Only the current version of Idris 2 is supported, which at the moment is 0.3.0. If you experience problems, please make sure you are using the most recent version.
+Only the current version of Idris 2 is supported, which at the moment is 0.4.0. If you experience problems, please make sure you are using the most recent version.
 
 At the moment, some of the IDE commands haven’t been implemented in Idris 2. There are no completions yet either.
 
@@ -164,6 +164,11 @@ The extension doesn’t set any key-bindings out of the box, but here are some s
   }
 ]
 ```
+
+## Literate Idris
+The extension should work equally well for literate Idris files. For [Idris 1](https://docs.idris-lang.org/en/latest/tutorial/miscellany.html#literate-programming), this only applies to .lidr files. [Idris 2](https://idris2.readthedocs.io/en/latest/reference/literate.html) extends this this to embedded code blocks in Markdown, LaTeX and Org-Mode files. However, the extension will only activate automatically for `.idr` and `.lidr` files. In order to use it for other file types, it may need be activated manually, with the `Idris: Activate Extension` command, if you have not previously opened any Idris files.
+
+LaTeX and Org-Mode are not yet implemented, but Markdown support is.
 
 ## Semantic Highlighting
 The apropos, browse namespace, documentation and definition commands use VS’s semantic highlighting API to colourise their output. If you don’t see any highlighting, it’s likely that your theme doesn’t support it yet.

--- a/package.json
+++ b/package.json
@@ -17,11 +17,16 @@
   ],
   "activationEvents": [
     "onLanguage:idris",
-    "onLanguage:lidr"
+    "onLanguage:lidr",
+    "onCommand:idris.activate"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
+      {
+        "command": "idris.activate",
+        "title": "Idris: Activate Extension"
+      },
       {
         "command": "idris.addClause",
         "title": "Idris: Add Clause"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,7 +11,7 @@ import {
   currentSelection,
 } from "./editing"
 import { stitchBrowseNamespace, stitchMetavariables } from "./message-stitching"
-import { state } from "./state"
+import { state, supportedLanguages } from "./state"
 
 /**
  * Many of the calls that accept the name of a metavariable don’t expect the
@@ -283,7 +283,7 @@ export const printDefinitionSelection = (client: IdrisClient) => async () => {
 export const loadFile = async (client: IdrisClient, document: vscode.TextDocument): Promise<void> => {
   if (state.statusMessage) state.statusMessage.dispose()
 
-  if (document.languageId === "idris" || document.languageId === "lidr" || document.languageId === "markdown") {
+  if (supportedLanguages(state).includes(document.languageId)) {
     const reply = await client.loadFile(document.fileName)
     if (reply.ok) {
       state.currentFile = document.fileName

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -298,6 +298,9 @@ export const loadFile = async (client: IdrisClient, document: vscode.TextDocumen
 }
 
 // Some lidr replies have duplicated `> `s, mixed up with whitespace. Sigh.
+// See https://github.com/meraymond2/idris-ide-client/blob/main/test/client/v2-lidr.test.ts
+// for examples of the malformed resposnes.
+// TODO: This works, but I think it can be simplified considerably, and could use units tests.
 const fixLidrPrefix = (s: string): string => {
   if (s.startsWith("> > ")) {
     const fixed = s.replace(/^(> )+/, "")

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -283,7 +283,7 @@ export const printDefinitionSelection = (client: IdrisClient) => async () => {
 export const loadFile = async (client: IdrisClient, document: vscode.TextDocument): Promise<void> => {
   if (state.statusMessage) state.statusMessage.dispose()
 
-  if (document.languageId === "idris" || document.languageId === "lidr") {
+  if (document.languageId === "idris" || document.languageId === "lidr" || document.languageId === "markdown") {
     const reply = await client.loadFile(document.fileName)
     if (reply.ok) {
       state.currentFile = document.fileName

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -12,6 +12,7 @@ import {
 } from "./editing"
 import { stitchBrowseNamespace, stitchMetavariables } from "./message-stitching"
 import { state, supportedLanguages } from "./state"
+import { isExtLanguage } from "./languages"
 
 /**
  * Many of the calls that accept the name of a metavariable don’t expect the
@@ -283,7 +284,7 @@ export const printDefinitionSelection = (client: IdrisClient) => async () => {
 export const loadFile = async (client: IdrisClient, document: vscode.TextDocument): Promise<void> => {
   if (state.statusMessage) state.statusMessage.dispose()
 
-  if (supportedLanguages(state).includes(document.languageId)) {
+  if (isExtLanguage(document.languageId) && supportedLanguages(state).includes(document.languageId)) {
     const reply = await client.loadFile(document.fileName)
     if (reply.ok) {
       state.currentFile = document.fileName

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ const promptReload = () => {
 }
 
 export const activate = (context: vscode.ExtensionContext) => {
+  vscode.window.showInformationMessage("ACTIVATION!!!!!")
   initialiseState()
   const { client, diagnostics, virtualDocState } = state
   if (client === null) {
@@ -97,6 +98,8 @@ export const activate = (context: vscode.ExtensionContext) => {
   })
 
   /* Commands */
+  context.subscriptions.push(vscode.commands.registerCommand("idris.activate", () => {}))
+
   context.subscriptions.push(vscode.commands.registerCommand("idris.addClause", addClause(client)))
 
   context.subscriptions.push(vscode.commands.registerCommand("idris.addMissing", addMissing(client)))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,7 +98,11 @@ export const activate = (context: vscode.ExtensionContext) => {
   })
 
   /* Commands */
-  context.subscriptions.push(vscode.commands.registerCommand("idris.activate", () => {}))
+  context.subscriptions.push(
+    vscode.commands.registerCommand("idris.activate", () => {
+      if (vscode.window.activeTextEditor) syncFileInfo(vscode.window.activeTextEditor.document)
+    })
+  )
 
   context.subscriptions.push(vscode.commands.registerCommand("idris.addClause", addClause(client)))
 

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,1 +1,3 @@
-export type Lanuage = "idris" | "lidr" | "markdown"
+export type ExtLanguage = "idris" | "lidr" | "markdown"
+
+export const isExtLanguage = (s: string): s is ExtLanguage => ["idris", "lidr", "markdown"].includes(s)

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,0 +1,1 @@
+export type Lanuage = "idris" | "lidr" | "markdown"

--- a/src/message-stitching.ts
+++ b/src/message-stitching.ts
@@ -64,7 +64,7 @@ export const stitchBrowseNamespace = (subModules: string[], decls: Decl[]): Virt
  * The metavariables reply has a list of metavars, each with a list of other
  * vars that are in its scope. The metavar and each of the other vars have their
  * own metadata. In order to put these into a single document, with correctly
- * relative tokens, We stitch all of the text into a single document
+ * relative tokens, we stitch all of the text into a single document
  * (string), with adjusted metadata positions.
  *
  * TODO: add the scope vars to the output.

--- a/src/providers/completions.ts
+++ b/src/providers/completions.ts
@@ -62,5 +62,3 @@ export class Provider implements vscode.CompletionItemProvider {
     })
   }
 }
-
-export const selector = { language: "idris" }

--- a/src/providers/doc-state-parser.ts
+++ b/src/providers/doc-state-parser.ts
@@ -1,0 +1,218 @@
+import * as vscode from "vscode"
+
+/**
+ * When hovering, we don’t want to activate unless the cursor is over code,
+ * because the call to the IDE process is mainly based on names, not so much
+ * position. Otherwise it will trigger in comments, in strings, and in literate
+ * and markdown files, in the text.
+ *
+ * Ideally this would happen in the IDE, which has already parsed the code, but
+ * since it doesn’t, we parse the file here, very coarsely, just to see if it’s
+ * in code or not.
+ */
+
+export type DocState =
+  | "code" // abc
+  | "line-comment" // -- abc
+  | "block-comment" // {- abc -}
+  | "doc-comment" // ||| abc
+  | "string" // "abc"
+  | "multi-line-string" // """abc"""
+
+type Delimiter =
+  | "string-delim"
+  | "multi-line-string-delim"
+  | "new-line"
+  | "start-line-comment"
+  | "start-block-comment"
+  | "end-block-comment"
+  | "start-doc-comment"
+
+export class DocStateParser {
+  private text: string
+  private endPos: vscode.Position
+  private state: DocState
+  private line: number // current line number in document
+  private col: number // current column number on current line
+  private pos: number // position in text-string
+
+  constructor(text: string, endPos: vscode.Position) {
+    this.text = text
+    this.endPos = endPos
+    this.state = "code"
+    this.line = 0
+    this.col = 0
+    this.pos = 0
+  }
+
+  static nextState = (currentState: DocState, delim: Delimiter): DocState => {
+    switch (currentState) {
+      case "code":
+        switch (delim) {
+          case "string-delim":
+            return "string"
+          case "multi-line-string-delim":
+            return "multi-line-string"
+          case "start-line-comment":
+            return "line-comment"
+          case "start-block-comment":
+            return "block-comment"
+          case "start-doc-comment":
+            return "doc-comment"
+          default:
+            return "code"
+        }
+      case "line-comment":
+        switch (delim) {
+          case "new-line":
+            return "code"
+          default:
+            return "line-comment"
+        }
+      case "block-comment":
+        switch (delim) {
+          case "end-block-comment":
+            return "code"
+          default:
+            return "block-comment"
+        }
+      case "doc-comment":
+        switch (delim) {
+          case "new-line":
+            return "code"
+          default:
+            return "doc-comment"
+        }
+      case "string":
+        switch (delim) {
+          case "string-delim":
+            return "code"
+          default:
+            return "string"
+        }
+      case "multi-line-string":
+        switch (delim) {
+          case "multi-line-string-delim":
+            return "code"
+          default:
+            return "multi-line-string"
+        }
+    }
+  }
+
+  incLine = (): void => {
+    this.line += 1
+    this.col = 0
+  }
+
+  consumeNextDelim = (): Delimiter | null => {
+    switch (this.state) {
+      case "code": {
+        if (this.text[this.pos] === '"' && this.text[this.pos + 1] === '"' && this.text[this.pos + 2] === '"') {
+          this.pos += 3
+          this.col += 3
+          return "multi-line-string-delim"
+        } else if (this.text[this.pos] === '"') {
+          this.pos += 1
+          this.col += 1
+          return "string-delim"
+        } else if (this.text[this.pos] === "-" && this.text[this.pos + 1] === "-") {
+          this.pos += 2
+          this.col += 2
+          return "start-line-comment"
+        } else if (this.text[this.pos] === "{" && this.text[this.pos + 1] === "-") {
+          this.pos += 2
+          this.col += 2
+          return "start-block-comment"
+        } else if (this.text[this.pos] === "|" && this.text[this.pos + 1] === "|" && this.text[this.pos + 2] === "|") {
+          this.pos += 3
+          this.col += 3
+          return "start-doc-comment"
+        } else return null
+      }
+      case "line-comment": {
+        if (this.text[this.pos] === "\n") {
+          this.incLine()
+          this.pos += 1
+          return "new-line"
+        } else {
+          return null
+        }
+      }
+      case "block-comment": {
+        if (this.text[this.pos] === "-" && this.text[this.pos + 1] === "}") {
+          this.pos += 2
+          this.col += 2
+          return "end-block-comment"
+        } else {
+          return null
+        }
+      }
+      case "doc-comment": {
+        if (this.text[this.pos] === "\n") {
+          this.incLine()
+          this.pos += 1
+          return "new-line"
+        } else {
+          return null
+        }
+      }
+      case "string": {
+        if (this.text[this.pos] === '"') {
+          let escapes = 0
+          while (this.text[this.pos - (1 + escapes)] === "\\") {
+            escapes += 1
+          }
+          const quotesAreEscaped = escapes % 2 !== 0
+          if (quotesAreEscaped) return null
+          else {
+            this.pos += 1
+            this.col += 1
+            return "string-delim"
+          }
+        } else {
+          return null
+        }
+      }
+      case "multi-line-string": {
+        if (this.text[this.pos] === '"' && this.text[this.pos + 1] === '"' && this.text[this.pos + 2] === '"') {
+          let escapes = 0
+          while (this.text[this.pos - (1 + escapes)] === "\\") {
+            escapes += 1
+          }
+          const quotesAreEscaped = escapes % 2 !== 0
+          if (quotesAreEscaped) return null
+          else {
+            this.pos += 3
+            this.col += 3
+            return "multi-line-string-delim"
+          }
+        } else {
+          return null
+        }
+      }
+    }
+  }
+
+  atEndPos = (): boolean => {
+    return this.line >= this.endPos.line && this.col >= this.endPos.character
+  }
+
+  parseToEndPos = (): DocState => {
+    while (!this.atEndPos()) {
+      const delim = this.consumeNextDelim()
+      if (delim) {
+        this.state = DocStateParser.nextState(this.state, delim)
+      } else {
+        if (this.text[this.pos] === "\n") {
+          this.incLine()
+          this.pos += 1
+        } else {
+          this.pos += 1
+          this.col += 1
+        }
+      }
+    }
+    return this.state
+  }
+}

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -2,7 +2,6 @@ import * as vscode from "vscode"
 import { IdrisClient } from "idris-ide-client"
 import { state } from "../state"
 import { v2Only } from "../commands"
-export const selector = [{ language: "idris" }, { language: "lidr" }, { language: "markdown" }]
 
 type DocState =
   | "code" // abc

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode"
 import { IdrisClient } from "idris-ide-client"
 import { state } from "../state"
 import { v2Only } from "../commands"
-export const selector = [{ language: "idris" }, { language: "lidr" }]
+export const selector = [{ language: "idris" }, { language: "lidr" }, { language: "markdown" }]
 
 type DocState =
   | "code" // abc
@@ -285,6 +285,7 @@ export class Provider implements vscode.HoverProvider {
     position: vscode.Position,
     _token: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.Hover> {
+    if (document.languageId === "markdown") return { contents: [{ value: "Lunabee", language: "idris" }] }
     switch (state.hoverAction) {
       case "Nothing":
         return null

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -2,246 +2,82 @@ import * as vscode from "vscode"
 import { IdrisClient } from "idris-ide-client"
 import { state } from "../state"
 import { v2Only } from "../commands"
-
-type DocState =
-  | "code" // abc
-  | "line-comment" // -- abc
-  | "block-comment" // {- abc -}
-  | "doc-comment" // ||| abc
-  | "string" // "abc"
-  | "multi-line-string" // """abc"""
-
-type Delimiter =
-  | "string-delim"
-  | "multi-line-string-delim"
-  | "new-line"
-  | "start-line-comment"
-  | "start-block-comment"
-  | "end-block-comment"
-  | "start-doc-comment"
-
-class DocStateParser {
-  private text: string
-  private endPos: vscode.Position
-  private state: DocState
-  private line: number // current line number in document
-  private col: number // current column number on current line
-  private pos: number // position in text-string
-
-  constructor(text: string, endPos: vscode.Position) {
-    this.text = text
-    this.endPos = endPos
-    this.state = "code"
-    this.line = 0
-    this.col = 0
-    this.pos = 0
-
-    this.consumeNextDelim = this.consumeNextDelim.bind(this)
-    this.atEndPos = this.atEndPos.bind(this)
-    this.incLine = this.incLine.bind(this)
-    this.parseToEndPos = this.parseToEndPos.bind(this)
-  }
-
-  static nextState(currentState: DocState, delim: Delimiter): DocState {
-    switch (currentState) {
-      case "code":
-        switch (delim) {
-          case "string-delim":
-            return "string"
-          case "multi-line-string-delim":
-            return "multi-line-string"
-          case "start-line-comment":
-            return "line-comment"
-          case "start-block-comment":
-            return "block-comment"
-          case "start-doc-comment":
-            return "doc-comment"
-          default:
-            return "code"
-        }
-      case "line-comment":
-        switch (delim) {
-          case "new-line":
-            return "code"
-          default:
-            return "line-comment"
-        }
-      case "block-comment":
-        switch (delim) {
-          case "end-block-comment":
-            return "code"
-          default:
-            return "block-comment"
-        }
-      case "doc-comment":
-        switch (delim) {
-          case "new-line":
-            return "code"
-          default:
-            return "doc-comment"
-        }
-      case "string":
-        switch (delim) {
-          case "string-delim":
-            return "code"
-          default:
-            return "string"
-        }
-      case "multi-line-string":
-        switch (delim) {
-          case "multi-line-string-delim":
-            return "code"
-          default:
-            return "multi-line-string"
-        }
-    }
-  }
-
-  incLine(): void {
-    this.line += 1
-    this.col = 0
-  }
-
-  consumeNextDelim(): Delimiter | null {
-    switch (this.state) {
-      case "code": {
-        if (this.text[this.pos] === '"' && this.text[this.pos + 1] === '"' && this.text[this.pos + 2] === '"') {
-          this.pos += 3
-          this.col += 3
-          return "multi-line-string-delim"
-        } else if (this.text[this.pos] === '"') {
-          this.pos += 1
-          this.col += 1
-          return "string-delim"
-        } else if (this.text[this.pos] === "-" && this.text[this.pos + 1] === "-") {
-          this.pos += 2
-          this.col += 2
-          return "start-line-comment"
-        } else if (this.text[this.pos] === "{" && this.text[this.pos + 1] === "-") {
-          this.pos += 2
-          this.col += 2
-          return "start-block-comment"
-        } else if (this.text[this.pos] === "|" && this.text[this.pos + 1] === "|" && this.text[this.pos + 2] === "|") {
-          this.pos += 3
-          this.col += 3
-          return "start-doc-comment"
-        } else return null
-      }
-      case "line-comment": {
-        if (this.text[this.pos] === "\n") {
-          this.incLine()
-          this.pos += 1
-          return "new-line"
-        } else {
-          return null
-        }
-      }
-      case "block-comment": {
-        if (this.text[this.pos] === "-" && this.text[this.pos + 1] === "}") {
-          this.pos += 2
-          this.col += 2
-          return "end-block-comment"
-        } else {
-          return null
-        }
-      }
-      case "doc-comment": {
-        if (this.text[this.pos] === "\n") {
-          this.incLine()
-          this.pos += 1
-          return "new-line"
-        } else {
-          return null
-        }
-      }
-      case "string": {
-        if (this.text[this.pos] === '"') {
-          let escapes = 0
-          while (this.text[this.pos - (1 + escapes)] === "\\") {
-            escapes += 1
-          }
-          const quotesAreEscaped = escapes % 2 !== 0
-          if (quotesAreEscaped) return null
-          else {
-            this.pos += 1
-            this.col += 1
-            return "string-delim"
-          }
-        } else {
-          return null
-        }
-      }
-      case "multi-line-string": {
-        if (this.text[this.pos] === '"' && this.text[this.pos + 1] === '"' && this.text[this.pos + 2] === '"') {
-          let escapes = 0
-          while (this.text[this.pos - (1 + escapes)] === "\\") {
-            escapes += 1
-          }
-          const quotesAreEscaped = escapes % 2 !== 0
-          if (quotesAreEscaped) return null
-          else {
-            this.pos += 3
-            this.col += 3
-            return "multi-line-string-delim"
-          }
-        } else {
-          return null
-        }
-      }
-    }
-  }
-
-  atEndPos(): boolean {
-    return this.line >= this.endPos.line && this.col >= this.endPos.character
-  }
-
-  parseToEndPos(): DocState {
-    while (!this.atEndPos()) {
-      const delim = this.consumeNextDelim()
-      if (delim) {
-        this.state = DocStateParser.nextState(this.state, delim)
-      } else {
-        if (this.text[this.pos] === "\n") {
-          this.incLine()
-          this.pos += 1
-        } else {
-          this.pos += 1
-          this.col += 1
-        }
-      }
-    }
-    return this.state
-  }
-}
+import { DocState, DocStateParser } from "./doc-state-parser"
+import { isExtLanguage } from "../languages"
 
 const lidrLineIsCode = (document: vscode.TextDocument, line: number): boolean =>
   document.lineAt(line).text.trim().startsWith(">")
 
-const overCode = (document: vscode.TextDocument, position: vscode.Position): boolean => {
-  if (document.languageId === "idris") {
-    const parser = new DocStateParser(document.getText(), position)
-    const docStateAtPos = parser.parseToEndPos()
-    return docStateAtPos === "code"
-  } else if (document.languageId === "lidr") {
-    const inCodeBlock = lidrLineIsCode(document, position.line)
-    if (!inCodeBlock) return false
+const openingMarkdownBlock = (line: string): boolean => /^(```|~~~)idris/.test(line.trim())
+const closingMarkdownBlock = (line: string): boolean => /^(```|~~~)\s*$/.test(line.trim())
 
-    // Run the DocStateParser on just the code block that the hover position is within.
-    let blockStartLine = position.line
-    let blockEndLine = position.line
-    while (lidrLineIsCode(document, blockStartLine) && blockStartLine > 0) blockStartLine--
-    while (lidrLineIsCode(document, blockEndLine) && blockEndLine <= document.lineCount) blockEndLine++
-    const blockStart = new vscode.Position(blockStartLine, 0)
-    const blockEnd = new vscode.Position(blockEndLine + 1, 0)
-    const block = new vscode.Range(blockStart, blockEnd)
-    const relativePos = new vscode.Position(position.line - blockStartLine, position.character)
-    const parser = new DocStateParser(document.getText(block), relativePos)
-    const docStateAtPos = parser.parseToEndPos()
-    return docStateAtPos === "code"
-  } else if (document.languageId === "markdown") {
-    return true // TODO!
+const getStateWithinBlock = (
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  startLine: number,
+  endLine: number
+): DocState => {
+  const blockStart = new vscode.Position(startLine, 0)
+  const blockEnd = new vscode.Position(endLine, 0)
+  const block = new vscode.Range(blockStart, blockEnd)
+  const relativePos = new vscode.Position(position.line - startLine, position.character)
+  const parser = new DocStateParser(document.getText(block), relativePos)
+  return parser.parseToEndPos()
+}
+/**
+ * The, perhaps imperfectly named, DocStateParser determines whether the cursor is
+ * over code within a source file. For literate Idris and markdown files, we first
+ * need to determine if we’re within a code block at all. If so, we pass just that
+ * code block to the DocStateParser, to see if within that block the cursor is
+ * pointing at code.
+ */
+const overCode = (document: vscode.TextDocument, position: vscode.Position): boolean => {
+  const lang = document.languageId
+  if (!isExtLanguage(lang)) return false
+
+  switch (lang) {
+    case "idris": {
+      const parser = new DocStateParser(document.getText(), position)
+      const docStateAtPos = parser.parseToEndPos()
+      return docStateAtPos === "code"
+    }
+    case "lidr": {
+      const inCodeBlock = lidrLineIsCode(document, position.line)
+      if (!inCodeBlock) return false
+
+      // Run the DocStateParser on just the code block that the hover position is within.
+      let blockStartLine = position.line
+      let blockEndLine = position.line
+      while (lidrLineIsCode(document, blockStartLine) && blockStartLine > 0) blockStartLine--
+      while (lidrLineIsCode(document, blockEndLine) && blockEndLine <= document.lineCount) blockEndLine++
+
+      return getStateWithinBlock(document, position, blockStartLine, blockEndLine + 1) === "code"
+    }
+    case "markdown": {
+      const hoverLineText = document.lineAt(position.line).text
+      // If we’re over a markdown code block delimeter, it’s not Idris code.
+      if (openingMarkdownBlock(hoverLineText) || closingMarkdownBlock(hoverLineText)) return false
+
+      // Look for opening of Idris code block.
+      let blockStartLine = position.line
+      while (blockStartLine > 0) {
+        blockStartLine--
+        const lineText = document.lineAt(blockStartLine).text
+        if (openingMarkdownBlock(lineText)) break
+        if (closingMarkdownBlock(lineText)) return false // we’re not in a code block
+      }
+      if (blockStartLine === 0) return false // we’ve reached the start without finding the opening of a code block
+
+      // If we’ve gotten this far, we’re definitely within a code block.
+      let blockEndLine = position.line
+      while (blockEndLine <= document.lineCount) {
+        blockEndLine++
+        const lineText = document.lineAt(blockStartLine).text
+        if (closingMarkdownBlock(lineText)) break
+      }
+      return getStateWithinBlock(document, position, blockStartLine + 1, blockEndLine) === "code"
+    }
   }
-  return false
 }
 
 const typeOf =

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -239,6 +239,8 @@ const overCode = (document: vscode.TextDocument, position: vscode.Position): boo
     const parser = new DocStateParser(document.getText(block), relativePos)
     const docStateAtPos = parser.parseToEndPos()
     return docStateAtPos === "code"
+  } else if (document.languageId === "markdown") {
+    return true // TODO!
   }
   return false
 }
@@ -285,7 +287,6 @@ export class Provider implements vscode.HoverProvider {
     position: vscode.Position,
     _token: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.Hover> {
-    if (document.languageId === "markdown") return { contents: [{ value: "Lunabee", language: "idris" }] }
     switch (state.hoverAction) {
       case "Nothing":
         return null

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, spawn } from "child_process"
 import { IdrisClient, Reply } from "idris-ide-client"
 import * as vscode from "vscode"
-import { Lanuage } from "./languages"
+import { ExtLanguage } from "./languages"
 import { handleWarning } from "./providers/diagnostics"
 import { VirtualDocInfo } from "./providers/virtual-docs"
 
@@ -86,5 +86,5 @@ export const initialiseState = () => {
   if (hoverAction) state.hoverAction = hoverAction
 }
 
-export const supportedLanguages = (state: State): Lanuage[] =>
+export const supportedLanguages = (state: State): ExtLanguage[] =>
   state.idris2Mode ? ["idris", "lidr", "markdown"] : ["idris", "lidr"]

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,6 +1,7 @@
 import { ChildProcess, spawn } from "child_process"
 import { IdrisClient, Reply } from "idris-ide-client"
 import * as vscode from "vscode"
+import { Lanuage } from "./languages"
 import { handleWarning } from "./providers/diagnostics"
 import { VirtualDocInfo } from "./providers/virtual-docs"
 
@@ -84,3 +85,6 @@ export const initialiseState = () => {
   if (autosave) state.autosave = autosave
   if (hoverAction) state.hoverAction = hoverAction
 }
+
+export const supportedLanguages = (state: State): Lanuage[] =>
+  state.idris2Mode ? ["idris", "lidr", "markdown"] : ["idris", "lidr"]


### PR DESCRIPTION
### Added
- `Idris: Activate Extension` command, to manually activate when working with non-idris files.
- Support for commands in idris2 blocks in markdown files.
### Fixed
- Support completions for Idris 1 .lidr files.

Aside from quoting the changelog, I'll mention that as far as I can tell, there is [no way](https://github.com/microsoft/vscode/issues/98621#issuecomment-680995639) to activate an extension based on an embedded language. I'm also not willing to activate this extension on every markdown file. I experimented with making a separate languageId for .lidr.md files, but then you lose the normal markdown behaviour. 

The least-bad option I've come up with is to add a manual activation command, so if you want to write Idris in markdown files, and the extension hasn't already been activated you can do so. (I checked out the Agda extension's behaviour, per https://github.com/meraymond2/idris-vscode/issues/53, and they appear to do something similar.)

I've been writing unit tests over in https://github.com/meraymond2/idris-ide-client, and all the commands work perfectly fine for markdown files, with a few quirks.
- separate blocks are treated as one combined file
- if you have .lidr or .md files with the same basename as an .idr file, it will report errors for the .idr file, which messes up the diagnostics