### PR TITLE
Add separate commands for type-of/at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 ### Added
+- Add separate commands for :type-of and :type-at. 
 ### Changed
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ The extension doesn’t set any key-bindings out of the box, but here are some s
     "key": "ctrl+alt+p",
     "command": "idris.proofSearch",
     "when": "editorLangId == idris && editorTextFocus"
+  },
+  {
+    "key": "ctrl+alt+t",
+    "command": "idris.typeAt",
+    "when": "editorLangId == idris && editorTextFocus"
   }
 ]
 ```

--- a/package.json
+++ b/package.json
@@ -96,6 +96,14 @@
         "title": "Idris: Proof Search"
       },
       {
+        "command": "idris.typeAt",
+        "title": "Idris: Type At"
+      },
+      {
+        "command": "idris.typeOf",
+        "title": "Idris: Type Of"
+      },
+      {
         "command": "idris.version",
         "title": "Idris: Version"
       }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -390,6 +390,8 @@ export const proofSearch = (client: IdrisClient) => async () => {
 }
 
 export const typeAt = (client: IdrisClient) => async () => {
+  if (!state.idris2Mode) return v2Only("Type At")
+
   const selection = currentWord()
   if (selection) {
     const { name, line, range } = selection
@@ -399,7 +401,7 @@ export const typeAt = (client: IdrisClient) => async () => {
     if (reply.ok) {
       state.outputChannel.clear()
       state.outputChannel.append(reply.typeAt)
-      state.outputChannel.show(Boolean("preserveFocus"))
+      state.outputChannel.show(true)
     }
   }
 }
@@ -414,7 +416,7 @@ export const typeOf = (client: IdrisClient) => async () => {
     if (reply.ok) {
       state.outputChannel.clear()
       state.outputChannel.append(reply.typeOf)
-      state.outputChannel.show(Boolean("preserveFocus"))
+      state.outputChannel.show(true)
     }
   }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -389,6 +389,36 @@ export const proofSearch = (client: IdrisClient) => async () => {
   }
 }
 
+export const typeAt = (client: IdrisClient) => async () => {
+  const selection = currentWord()
+  if (selection) {
+    const { name, line, range } = selection
+    const trimmed = name.startsWith("?") ? name.slice(1, name.length) : name
+    await ensureLoaded(client)
+    const reply = await client.typeAt(trimmed, line + 1, range.start.character)
+    if (reply.ok) {
+      state.outputChannel.clear()
+      state.outputChannel.append(reply.typeAt)
+      state.outputChannel.show(Boolean("preserveFocus"))
+    }
+  }
+}
+
+export const typeOf = (client: IdrisClient) => async () => {
+  const selection = currentWord()
+  if (selection) {
+    const { name } = selection
+    const trimmed = name.startsWith("?") ? name.slice(1, name.length) : name
+    await ensureLoaded(client)
+    const reply = await client.typeOf(trimmed)
+    if (reply.ok) {
+      state.outputChannel.clear()
+      state.outputChannel.append(reply.typeOf)
+      state.outputChannel.show(Boolean("preserveFocus"))
+    }
+  }
+}
+
 export const version = (client: IdrisClient) => async () => {
   const { major, minor, patch, tags } = await client.version()
   const nonEmptyTags = tags.filter(Boolean)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,8 @@ import {
   printDefinition,
   printDefinitionSelection,
   proofSearch,
+  typeAt,
+  typeOf,
   version,
 } from "./commands"
 import * as completions from "./providers/completions"
@@ -141,6 +143,10 @@ export const activate = async (context: vscode.ExtensionContext) => {
   context.subscriptions.push(vscode.commands.registerCommand("idris.makeWith", makeWith(client)))
 
   context.subscriptions.push(vscode.commands.registerCommand("idris.proofSearch", proofSearch(client)))
+
+  context.subscriptions.push(vscode.commands.registerCommand("idris.typeAt", typeAt(client)))
+
+  context.subscriptions.push(vscode.commands.registerCommand("idris.typeOf", typeOf(client)))
 
   context.subscriptions.push(vscode.commands.registerCommand("idris.version", version(client)))
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -20,6 +20,7 @@ export interface State {
   idrisProc: ChildProcess | null
   idrisProcDir: string | null
   idris2Mode: boolean
+  outputChannel: vscode.OutputChannel
   statusMessage: vscode.Disposable | null
   virtualDocState: Record<string, VirtualDocInfo>
 }
@@ -33,6 +34,7 @@ export const state: State = {
   idrisProc: null,
   idrisProcDir: null,
   idris2Mode: false,
+  outputChannel: vscode.window.createOutputChannel("Idris"),
   statusMessage: null,
   virtualDocState: {},
 }


### PR DESCRIPTION
### Change
https://github.com/meraymond2/idris-vscode/issues/71

Allows `:type-of` and `:type-at` to be called as commands, so they can be assigned to keyboard shortcuts. At the moment, they're only available on hover.

### Output
I've gone with the output-channel to display the types. There are multiple ways of displaying information in VS, and none of them are great options.
- output channels lack [syntax highlighting](https://github.com/microsoft/vscode/issues/48890)
- information messages [don't allow newlines](https://github.com/microsoft/vscode/issues/48900#issuecomment-385332787)
- status bar would be too small and wouldn't allow newlines, modals would need closing
- for printing documentation and metavariables, I have been using virtual text documents, because the Idris 1 IDE provided syntactic highlighting for those. I think that would be too heavy for this. I'm tempted to switch all the Idris 2 docs to the output channel too, since there isn't any semantic highlighting yet, and it is more convenient than the virtual docs.