### PR TITLE
Bump pkg version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 ### Added
+### Changed
+### Fixed
+
+## 0.0.12
+### Added
 - Add separate commands for :type-of and :type-at. 
 ### Changed
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "idris-vscode",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "meraymond",
   "displayName": "Idris Language",
   "description": "Language support for Idris and Idris 2.",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 0.0.12
### Added
- Add separate commands for :type-of and :type-at. 
### Changed
### Fixed
- Until multiple workspaces are supported, adds an error message. 
