### PR TITLE
Configurable proc args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 ### Added
+- Added the ability to specify additional arguments for the Idris process.
 ### Changed
 ### Fixed
 - Fixed a bug in Idris v1 mode where it would erroneously show the workspace error message.  

--- a/package.json
+++ b/package.json
@@ -144,6 +144,14 @@
           ],
           "default": "Type Of",
           "description": "Configure which command should be called when hovering over a variable."
+        },
+        "idris.processArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Optional additional flags to pass to the Idris IDE process, e.g. `-p contrib`."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,7 +62,9 @@ export const activate = async (context: vscode.ExtensionContext) => {
       if (hoverAction) state.hoverAction = hoverAction
     }
     const procConfigChanged =
-      changeEvent.affectsConfiguration("idris.idrisPath") || changeEvent.affectsConfiguration("idris.idris2Mode")
+      changeEvent.affectsConfiguration("idris.idrisPath") ||
+      changeEvent.affectsConfiguration("idris.idris2Mode") ||
+      changeEvent.affectsConfiguration("idris.processArgs")
     if (procConfigChanged) {
       promptReload()
     }

--- a/src/state.ts
+++ b/src/state.ts
@@ -51,6 +51,7 @@ export const initialiseState = async () => {
   const extensionConfig = vscode.workspace.getConfiguration("idris")
   const idrisPath: string = extensionConfig.get("idrisPath") || ""
   const idris2Mode: boolean = extensionConfig.get("idris2Mode") || false
+  const additionalProcArgs: string[] = extensionConfig.get("processArgs") || []
   const autosave: AutoSaveBehaviour | undefined = extensionConfig.get("autosave")
   const hoverAction: HoverBehaviour | undefined = extensionConfig.get("hoverAction")
 
@@ -59,14 +60,19 @@ export const initialiseState = async () => {
   if (workspacePaths?.length === 1) {
     idrisProcDir = workspacePaths[0]
   } else {
-    vscode.window.showErrorMessage("Multiple workspaces are not currently supported, and most features may not work correctly.")
+    vscode.window.showErrorMessage(
+      "Multiple workspaces are not currently supported, and most features may not work correctly."
+    )
   }
 
   /* Idris2 won’t locate the ipkg file by default if the code is in another
   directory, so it’s necessary to pass the --find-ipkg flag. It looks for the ipkg
   in parent directories of the process, so it’s also necessary to start the Idris
   process in the workspace directory.*/
-  const procArgs = idris2Mode ? ["--ide-mode", "--find-ipkg", "--no-color"] : ["--ide-mode"]
+  const baseProcArgs = idris2Mode ? ["--ide-mode", "--find-ipkg", "--no-color"] : ["--ide-mode"]
+  const procArgs = baseProcArgs.concat(
+    additionalProcArgs.reduce<string[]>((acc, arg) => acc.concat(arg.split(/\s+/)), [])
+  )
 
   if (!idris2Mode) {
     const ipkgUries = await vscode.workspace.findFiles("*.ipkg")


### PR DESCRIPTION
For small programs, packages can be passed directly to the Idris compiler rather than recorded in an .ipkg file (see https://github.com/meraymond2/idris-vscode/issues/80). In order for the extension to support this, I'm adding a configuration option to allow passing arbitrary options to the Idris process. 

![image](https://user-images.githubusercontent.com/13559686/171450038-415a4c43-91f0-456f-bdc3-a64d60116814.png)

The _required_ flags will still be passed in automatically. 