### PR TITLE
fix 'Could not start Idris process' on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
+        "cross-spawn": "^7.0.3",
         "idris-ide-client": "^0.1.5"
       },
       "devDependencies": {
         "@types/chai": "4.2.21",
+        "@types/cross-spawn": "^6.0.2",
         "@types/mocha": "8.2.3",
         "@types/node": "14.17.2",
         "@types/vscode": "^1.44.0",
@@ -175,6 +177,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
       "integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
       "dev": true
+    },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.2.tgz",
+      "integrity": "sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.8",
@@ -747,7 +758,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1742,8 +1752,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2358,7 +2367,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2647,7 +2655,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -2659,7 +2666,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3101,7 +3107,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3427,6 +3432,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
       "integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
       "dev": true
+    },
+    "@types/cross-spawn": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.2.tgz",
+      "integrity": "sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/json-schema": {
       "version": "7.0.8",
@@ -3847,7 +3861,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4568,8 +4581,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -5045,8 +5057,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-type": {
       "version": "4.0.0",
@@ -5220,7 +5231,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -5228,8 +5238,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "side-channel": {
       "version": "1.0.4",
@@ -5560,7 +5569,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -232,10 +232,12 @@
     "test": "NODE_ENV=test npx mocha --recursive --require ts-node/register --extensions ts 'test/**/*.ts'"
   },
   "dependencies": {
+    "cross-spawn": "^7.0.3",
     "idris-ide-client": "^0.1.5"
   },
   "devDependencies": {
     "@types/chai": "4.2.21",
+    "@types/cross-spawn": "^6.0.2",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.2",
     "@types/vscode": "^1.44.0",

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,10 +1,11 @@
-import { ChildProcess, spawn } from "child_process"
+import { ChildProcess } from "child_process"
 import { IdrisClient, Reply } from "idris-ide-client"
 import * as vscode from "vscode"
 import { ExtLanguage } from "./languages"
 import { handleWarning } from "./providers/diagnostics"
 import { VirtualDocInfo } from "./providers/virtual-docs"
 import { extractPkgs } from "./ipkg"
+import { spawn } from "cross-spawn"
 
 // I’m not using the Memento API because I don’t want persistence across sessions, and I do want type-safety.
 
@@ -55,7 +56,7 @@ export const initialiseState = async () => {
   const autosave: AutoSaveBehaviour | undefined = extensionConfig.get("autosave")
   const hoverAction: HoverBehaviour | undefined = extensionConfig.get("hoverAction")
 
-  const workspacePaths = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.path)
+  const workspacePaths = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath)
   let idrisProcDir = null
   if (workspacePaths?.length === 1) {
     idrisProcDir = workspacePaths[0]


### PR DESCRIPTION
I tried to fix the bug of this plugin on windows.
This error is mentioned here: #33 .

This is because in windows, `spawn` is written differently, but [this library](https://www.npmjs.com/package/cross-spawn) unifies the writing in different environments.
Or you can also use the parameter `shell`:
```
spawn(xxx, { shell: true })
```

Another problem is that `fsPath` from `workspaceFolders` should be used, which will use platform-specific separators, while `path` use linux-style separators.

My modified code works fine on my windows.

I'm using idris1, I haven't tested the situation with idris2, but it looks like it has nothing to do with the version of idris, just a compatibility issue with different platforms.