### PR TITLE
V0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 ## Unreleased
 ### Added
 ### Changed
+### Fixed
+
+## 0.0.14
+### Added
+### Changed
 - Bumped the back-end to 0.1.6, to handle Idris2 0.6.0. 
 ### Fixed
 - Fixed a bug on Windows where it would fail to start the process.
+- Fixed error msgs being displayed incorrectly due to a change in how they're reported in Idris2 0.6.0.
 
 ## 0.0.13
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idris-vscode",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "idris-vscode",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT",
       "dependencies": {
         "idris-ide-client": "0.1.6"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "meraymond",
   "displayName": "Idris Language",
   "description": "Language support for Idris and Idris 2.",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 0.0.14
### Added
### Changed
- Bumped the back-end to 0.1.6, to handle Idris2 0.6.0. 
### Fixed
- Fixed a bug on Windows where it would fail to start the process.
- Fixed error msgs being displayed incorrectly due to a change in how they're reported in Idris2 0.6.0.