### PR TITLE
Add "idris2" support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "Programming Languages"
   ],
   "activationEvents": [
+    "onLanguage:idris2",
     "onLanguage:idris",
     "onLanguage:lidr",
     "onCommand:idris.activate"

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,3 +1,3 @@
-export type ExtLanguage = "idris" | "lidr" | "markdown"
+export type ExtLanguage = "idris2" | "idris" | "lidr" | "markdown"
 
-export const isExtLanguage = (s: string): s is ExtLanguage => ["idris", "lidr", "markdown"].includes(s)
+export const isExtLanguage = (s: string): s is ExtLanguage => ["idris2", "idris", "lidr", "markdown"].includes(s)

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -36,6 +36,7 @@ const overCode = (document: vscode.TextDocument, position: vscode.Position): boo
   if (!isExtLanguage(lang)) return false
 
   switch (lang) {
+    case "idris2":
     case "idris": {
       const parser = new DocStateParser(document.getText(), position)
       const docStateAtPos = parser.parseToEndPos()

--- a/src/state.ts
+++ b/src/state.ts
@@ -109,7 +109,7 @@ export const initialiseState = async () => {
 }
 
 export const supportedLanguages = (state: State): ExtLanguage[] =>
-  state.idris2Mode ? ["idris", "lidr", "markdown"] : ["idris", "lidr"]
+  state.idris2Mode ? ["idris2", "idris", "lidr", "markdown"] : ["idris", "lidr"]
 
 const readFile = async (uri: vscode.Uri): Promise<string> => {
   const readData = await vscode.workspace.fs.readFile(uri)


### PR DESCRIPTION
Add support for the language "idris2", in idris2-mode only.

If the extension `idr` is associated with the language "idris2" and `idris2Mode` is configured, treat the source file the same as an "idris" file.
The extension [Idris 2 Language Support for Visual Studio Code](https://github.com/j-nava/idris2-vscode) adds the language "idris2" to VS Code's languages.

See #91 